### PR TITLE
Fix prefix length for DNSName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+www/

--- a/mtc.go
+++ b/mtc.go
@@ -1338,7 +1338,7 @@ func (c *Claims) UnmarshalBinary(data []byte) error {
 
 			for !packed.Empty() {
 				var domain []byte
-				if !packed.ReadUint16LengthPrefixed((*cryptobyte.String)(&domain)) {
+				if !packed.ReadUint8LengthPrefixed((*cryptobyte.String)(&domain)) {
 					return ErrTruncated
 				}
 
@@ -1439,7 +1439,7 @@ func (c *Claims) MarshalBinary() ([]byte, error) {
 		b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) { // claim_info
 			b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) { // dns_names
 				for _, domain := range sorted {
-					b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
+					b.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
 						b.AddBytes([]byte(domain))
 					})
 				}


### PR DESCRIPTION
If I'm not mistaken, your implementation diverges from the most recent RFC draft in the encoding of the length for `DNSName`. Please have a look at [Section 4.1](https://datatracker.ietf.org/doc/html/draft-davidben-tls-merkle-tree-certs-03#name-dns-claims) as a reference.