### PR TITLE
Replace Dilithium with ML-DSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ life_time              3600       1h0m0s
 storage_window_size    24         2h0m0s
 validity_window_size   12
 http_server            ca.example.com/path
-public_key fingerprint ml-dsa-44:85b5a617ef109e0a8d68a094c8b969f622ac4096c513fa0acd169c231ce2fad5
+public_key fingerprint ml-dsa-87:85b5a617ef109e0a8d68a094c8b969f622ac4096c513fa0acd169c231ce2fad5
 ```
 
 The `batches` folder is empty, because there are no batches issued yet.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ life_time              3600       1h0m0s
 storage_window_size    24         2h0m0s
 validity_window_size   12
 http_server            ca.example.com/path
-public_key fingerprint dilithium5:85b5a617ef109e0a8d68a094c8b969f622ac4096c513fa0acd169c231ce2fad5
+public_key fingerprint ml-dsa-44:85b5a617ef109e0a8d68a094c8b969f622ac4096c513fa0acd169c231ce2fad5
 ```
 
 The `batches` folder is empty, because there are no batches issued yet.

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -1040,7 +1040,7 @@ func New(path string, opts NewOpts) (*Handle, error) {
 	h.params.Issuer = opts.Issuer
 
 	if opts.SignatureScheme == 0 {
-		opts.SignatureScheme = mtc.TLSDilitihium5r3
+		opts.SignatureScheme = mtc.TLSMLDSA44
 	}
 
 	// Generate keypair

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -1040,7 +1040,7 @@ func New(path string, opts NewOpts) (*Handle, error) {
 	h.params.Issuer = opts.Issuer
 
 	if opts.SignatureScheme == 0 {
-		opts.SignatureScheme = mtc.TLSMLDSA44
+		opts.SignatureScheme = mtc.TLSMLDSA87
 	}
 
 	// Generate keypair

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/bwesterb/mtc
 
-go 1.21.2
+go 1.23.3
 
 require (
-	github.com/cloudflare/circl v1.3.9
+	github.com/cloudflare/circl v1.5.0
 	github.com/nightlyone/lockfile v1.0.0
 	github.com/urfave/cli/v2 v2.27.1
 	golang.org/x/crypto v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/cloudflare/circl v1.3.9 h1:QFrlgFYf2Qpi8bSpVPK1HBvWpx16v/1TZivyo7pGuBE=
 github.com/cloudflare/circl v1.3.9/go.mod h1:PDRU+oXvdD7KCtgKxW95M5Z8BpSCJXQORiZFnBQS5QU=
+github.com/cloudflare/circl v1.5.0 h1:hxIWksrX6XN5a1L2TI/h53AGPhNHoUBo+TD1ms9+pys=
+github.com/cloudflare/circl v1.5.0/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=

--- a/mtc.go
+++ b/mtc.go
@@ -112,10 +112,10 @@ const (
 	TLSECDSAWithP521AndSHA512 SignatureScheme = 0x0603
 	TLSEd25519                SignatureScheme = 0x0807
 
-	// Just for testing we use round 3 Dilithium5 with a codepoint in the
-	// private use region. For production SPHINCS⁺-128s would be a better
-	// choice.
-	TLSDilitihium5r3 SignatureScheme = 0xfe3c
+	// Just for testing we use ML-DSA44 with a codepoint in the
+	// private use region.
+	// For production SLH-DSA-128s would be a better choice.
+	TLSMLDSA44 SignatureScheme = 0xfe3c
 )
 
 type AbridgedTLSSubject struct {

--- a/mtc.go
+++ b/mtc.go
@@ -112,10 +112,10 @@ const (
 	TLSECDSAWithP521AndSHA512 SignatureScheme = 0x0603
 	TLSEd25519                SignatureScheme = 0x0807
 
-	// Just for testing we use ML-DSA44 with a codepoint in the
+	// Just for testing we use ML-DSA-87 with a codepoint in the
 	// private use region.
 	// For production SLH-DSA-128s would be a better choice.
-	TLSMLDSA44 SignatureScheme = 0xfe3c
+	TLSMLDSA87 SignatureScheme = 0x0906
 )
 
 type AbridgedTLSSubject struct {


### PR DESCRIPTION
I had difficulties finding a compatible Rust implementation of the round 3 Dilithium implementation and propose switching to the now standardized successor ML-DSA for better compatibility.
As it is for testing purposes only, I chose ML-DSA-44 for now, but I'm open to replacing it with a more secure parameter set or even SLH-DSA-128s, if preferred.