### PR TITLE
Convert evidence to a list

### DIFF
--- a/ca/index.go
+++ b/ca/index.go
@@ -187,7 +187,7 @@ func ComputeIndex(aaReader, evReader io.Reader, w io.Writer) error {
 	})
 
 	seqno = uint64(0)
-	err = mtc.UnmarshalEvidenceEntries(evReader, func(offset int, _ *mtc.Evidence) error {
+	err = mtc.UnmarshalEvidenceLists(evReader, func(offset int, _ *mtc.EvidenceList) error {
 		entries[seqno].evidenceOffset = uint64(offset)
 		seqno++
 		return nil

--- a/http/server.go
+++ b/http/server.go
@@ -44,7 +44,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return s.server.Shutdown(ctx)
 }
 
-func assertionFromRequestUnchecked(r *http.Request) (*mtc.AssertionRequest, error) {
+func assertionRequestFromHTTPUnchecked(r *http.Request) (*mtc.AssertionRequest, error) {
 	var (
 		ar mtc.AssertionRequest
 	)
@@ -65,8 +65,8 @@ func assertionFromRequestUnchecked(r *http.Request) (*mtc.AssertionRequest, erro
 	}
 }
 
-func assertionFromRequest(r *http.Request) (*mtc.AssertionRequest, error) {
-	ar, err := assertionFromRequestUnchecked(r)
+func assertionRequestFromHTTP(r *http.Request) (*mtc.AssertionRequest, error) {
+	ar, err := assertionRequestFromHTTPUnchecked(r)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func handleCaQueue(path string) func(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		defer h.Close()
-		a, err := assertionFromRequest(r)
+		a, err := assertionRequestFromHTTP(r)
 		if err != nil {
 			http.Error(w, "invalid assertion", http.StatusBadRequest)
 			return
@@ -110,7 +110,7 @@ func handleCaCert(path string) func(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		defer h.Close()
-		a, err := assertionFromRequest(r)
+		a, err := assertionRequestFromHTTP(r)
 		if err != nil {
 			http.Error(w, "invalid assertion", http.StatusBadRequest)
 			return


### PR DESCRIPTION
  Convert evidence to a list

  - Use a list for evidence instead of a single value. This should allow
    evidence to be used more broadly than for X.509 chains in the future:
    (see https://github.com/davidben/merkle-tree-certs/issues/23).
  - Use lazy parsing for X.509 chain evidence.

  Unrelated:
  - bugfix: add open file descriptors to `aas` and `evs` maps.
  - When retrieving a certificate, double-check that the corresponding
    abridged assertion is present in the abridged-assertions file.
  - Rename http/server.go functions for consistency with cli.