### PR TITLE
Rename HttpServer to ServerPrefix, and do not listen on it directly      

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ batch_duration         300        5m0s
 life_time              3600       1h0m0s
 storage_window_size    24         2h0m0s
 validity_window_size   12
-http_server            ca.example.com/path
+server_prefix          ca.example.com/path
 public_key fingerprint ml-dsa-87:85b5a617ef109e0a8d68a094c8b969f622ac4096c513fa0acd169c231ce2fad5
 ```
 
@@ -406,7 +406,7 @@ batch_duration     300    5m0s
 life_time       3600    1h0m0s
 storage_window_size  24     2h0m0s
 validity_window_size  12
-http_server      localhost:8080
+server_prefix    ca.example.com/path
 public_key fingerprint ml-dsa-87:be1903a366b462b7b4e0010120d4b38279bbf4e350559b95e93671dbc4b821fc
 ```
 

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -30,8 +30,8 @@ var (
 )
 
 type NewOpts struct {
-	Issuer     mtc.RelativeOID
-	HttpServer string
+	Issuer       mtc.RelativeOID
+	ServerPrefix string
 
 	// Fields below are optional.
 
@@ -1337,7 +1337,7 @@ func New(path string, opts NewOpts) (*Handle, error) {
 
 	h.params.StartTime = uint64(time.Now().Unix())
 
-	h.params.HttpServer = opts.HttpServer
+	h.params.ServerPrefix = opts.ServerPrefix
 	h.params.Issuer = opts.Issuer
 	h.params.EvidencePolicy = opts.EvidencePolicy
 

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -363,59 +363,59 @@ func Open(path string) (*Handle, error) {
 	return &h, nil
 }
 
-func (h Handle) skPath() string {
+func (h *Handle) skPath() string {
 	return gopath.Join(h.path, "signing.key")
 }
 
-func (h Handle) paramsPath() string {
+func (h *Handle) paramsPath() string {
 	return gopath.Join(h.path, "www", "mtc", "v1", "ca-params")
 }
 
-func (h Handle) queuePath() string {
+func (h *Handle) queuePath() string {
 	return gopath.Join(h.path, "queue")
 }
 
-func (h Handle) revocationCachePath() string {
+func (h *Handle) revocationCachePath() string {
 	return gopath.Join(h.path, "revocation-cache")
 }
 
-func (h Handle) umbilicalRootsPath() string {
+func (h *Handle) umbilicalRootsPath() string {
 	return gopath.Join(h.path, "www", "mtc", "v1", "umbilical-roots.pem")
 }
 
-func (h Handle) treePath(number uint32) string {
+func (h *Handle) treePath(number uint32) string {
 	return gopath.Join(h.batchPath(number), "tree")
 }
 
-func (h Handle) indexPath(number uint32) string {
+func (h *Handle) indexPath(number uint32) string {
 	return gopath.Join(h.batchPath(number), "index")
 }
 
-func (h Handle) aaPath(number uint32) string {
+func (h *Handle) aaPath(number uint32) string {
 	return gopath.Join(h.batchPath(number), "abridged-assertions")
 }
 
-func (h Handle) evPath(number uint32) string {
+func (h *Handle) evPath(number uint32) string {
 	return gopath.Join(h.batchPath(number), "evidence")
 }
 
-func (h Handle) batchPath(number uint32) string {
+func (h *Handle) batchPath(number uint32) string {
 	return gopath.Join(h.batchesPath(), fmt.Sprintf("%d", number))
 }
 
-func (h Handle) latestBatchPath() string {
+func (h *Handle) latestBatchPath() string {
 	return gopath.Join(h.batchesPath(), "latest")
 }
 
-func (h Handle) batchesPath() string {
+func (h *Handle) batchesPath() string {
 	return gopath.Join(h.path, "www", "mtc", "v1", "batches")
 }
 
-func (h Handle) tmpPath() string {
+func (h *Handle) tmpPath() string {
 	return gopath.Join(h.path, "tmp")
 }
 
-func (h Handle) getSignedValidityWindow(number uint32) (
+func (h *Handle) getSignedValidityWindow(number uint32) (
 	*mtc.SignedValidityWindow, error) {
 	var w mtc.SignedValidityWindow
 

--- a/mtc.go
+++ b/mtc.go
@@ -29,7 +29,7 @@ type CAParams struct {
 	Lifetime           uint64
 	ValidityWindowSize uint64
 	StorageWindowSize  uint64
-	HttpServer         string
+	ServerPrefix       string
 	EvidencePolicy     EvidencePolicyType
 }
 
@@ -481,7 +481,7 @@ func (p *CAParams) MarshalBinary() ([]byte, error) {
 	b.AddUint64(p.ValidityWindowSize)
 	b.AddUint64(p.StorageWindowSize)
 	b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
-		b.AddBytes([]byte(p.HttpServer))
+		b.AddBytes([]byte(p.ServerPrefix))
 	})
 	b.AddUint16(uint16(p.EvidencePolicy))
 	return b.Bytes()
@@ -490,11 +490,11 @@ func (p *CAParams) MarshalBinary() ([]byte, error) {
 func (p *CAParams) UnmarshalBinary(data []byte) error {
 	s := cryptobyte.String(data)
 	var (
-		issuerBuf     []byte
-		pkBuf         []byte
-		httpServerBuf []byte
-		sigScheme     SignatureScheme
-		err           error
+		issuerBuf       []byte
+		pkBuf           []byte
+		serverPrefixBuf []byte
+		sigScheme       SignatureScheme
+		err             error
 	)
 
 	if !s.ReadUint8LengthPrefixed((*cryptobyte.String)(&issuerBuf)) ||
@@ -506,7 +506,7 @@ func (p *CAParams) UnmarshalBinary(data []byte) error {
 		!s.ReadUint64(&p.Lifetime) ||
 		!s.ReadUint64(&p.ValidityWindowSize) ||
 		!s.ReadUint64(&p.StorageWindowSize) ||
-		!s.ReadUint16LengthPrefixed((*cryptobyte.String)(&httpServerBuf)) ||
+		!s.ReadUint16LengthPrefixed((*cryptobyte.String)(&serverPrefixBuf)) ||
 		!s.ReadUint16((*uint16)(&p.EvidencePolicy)) {
 		return ErrTruncated
 	}
@@ -516,7 +516,7 @@ func (p *CAParams) UnmarshalBinary(data []byte) error {
 	}
 
 	p.Issuer = issuerBuf
-	p.HttpServer = string(httpServerBuf)
+	p.ServerPrefix = string(serverPrefixBuf)
 	p.PublicKey, err = UnmarshalVerifier(sigScheme, pkBuf)
 	if err != nil {
 		return err

--- a/mtc_test.go
+++ b/mtc_test.go
@@ -85,7 +85,7 @@ func createTestCA() *CAParams {
 		BatchDuration:      1,
 		Lifetime:           10,
 		ValidityWindowSize: 10,
-		HttpServer:         "example.com",
+		ServerPrefix:       "ca.example.com/path",
 	}
 	return &ret
 }


### PR DESCRIPTION
Rename HttpServer to ServerPrefix, which is closer to the terminology
used in https://datatracker.ietf.org/doc/html/rfc6962#section-4 and in
https://github.com/C2SP/C2SP/blob/main/static-ct-api.md#checkpoints to
describe the prefix of the CA server. In the future, this can be used as
an identifier for the server (e.g., as a checkpoint origin line).

Also do not listen on ServerPrefix directly with the 'mtc ca serve'
subcommand, since it may not be in 'host:port' format. The `listen-addr`
flag provides the listening address for the server, and we assume that
it's behind a reverse proxy that ensures that requests to ServerPrefix
are routed correctly.

Unrelated:
- Fix linter complaints about a lock being passed by value

Closes #22