### PR TITLE
mirror: check evidence

### DIFF
--- a/cmd/mtc/main.go
+++ b/cmd/mtc/main.go
@@ -1023,6 +1023,7 @@ func handleInspectEntries(cc *cli.Context) error {
 			be.Key(key[:])
 			w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
 			fmt.Fprintf(w, "key\t%x\n", key)
+			fmt.Fprintf(w, "not_after\t%s\n", be.NotAfter.UTC())
 			fmt.Fprintf(w, "subject_type\t%s\n", subj.Type())
 			switch subj := subj.(type) {
 			case *mtc.AbridgedTLSSubject:
@@ -1066,7 +1067,7 @@ func handleInspectCaParams(cc *cli.Context) error {
 	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
 	fmt.Fprintf(w, "issuer\t%s\n", p.Issuer)
 	fmt.Fprintf(w, "start_time\t%d\t%s\n", p.StartTime,
-		time.Unix(int64(p.StartTime), 0))
+		time.Unix(int64(p.StartTime), 0).UTC())
 	fmt.Fprintf(w, "batch_duration\t%d\t%s\n", p.BatchDuration,
 		time.Second*time.Duration(p.BatchDuration))
 	fmt.Fprintf(w, "life_time\t%d\t%s\n", p.Lifetime,

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -422,9 +422,7 @@ func (h *Handle) fetchBatch(number uint32) error {
 		evs mtc.EvidenceList
 	)
 
-	entryNumber := -1
-	for {
-		entryNumber++
+	for entryNumber := 0; ; entryNumber++ {
 		err1 := besC.Pull(&be)
 		err2 := evsC.Pull(&evs)
 		if err1 == mtc.EOF && err1 == err2 {
@@ -441,7 +439,7 @@ func (h *Handle) fetchBatch(number uint32) error {
 			return fmt.Errorf("building tree: %w", err)
 		}
 
-		// TODO Would the spec allow a small NotAfter?
+		// TODO Would the spec allow a NotAfter before batchStart?
 		//		What about not_after = batchStart?
 		if be.NotAfter.After(batchEnd) || be.NotAfter.Before(batchStart) {
 			return fmt.Errorf(

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -3,6 +3,8 @@ package mirror
 import (
 	"bufio"
 	"bytes"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -14,10 +16,21 @@ import (
 
 	"github.com/bwesterb/mtc"
 	"github.com/bwesterb/mtc/internal"
+	"github.com/bwesterb/mtc/umbilical"
+	"github.com/bwesterb/mtc/umbilical/frozencas"
 )
 
 type NewOpts struct {
 	ServerPrefix string
+
+	// Fields below are optional
+
+	// Errors if the CA doesn't have the given evidence policy.
+	ExpectedEvidencePolicy mtc.EvidencePolicyType
+
+	// Lists of accepted roots for umbilical chains. If unset, we'll fetch
+	// the roots advertised by the CA itself.
+	UmbilicalRootsPEM []byte
 }
 
 type Handle struct {
@@ -112,6 +125,15 @@ func New(path string, opts NewOpts) (*Handle, error) {
 		)
 	}
 
+	if opts.ExpectedEvidencePolicy != mtc.UnsetEvidencePolicy &&
+		opts.ExpectedEvidencePolicy != params.EvidencePolicy {
+		return nil, fmt.Errorf(
+			"expected evidence policy %d; got %d",
+			opts.ExpectedEvidencePolicy,
+			params.EvidencePolicy,
+		)
+	}
+
 	// Set up basic file structure and write out params to disk
 	if err := h.b.New(path, params); err != nil {
 		return nil, err
@@ -123,6 +145,33 @@ func New(path string, opts NewOpts) (*Handle, error) {
 			_ = h.b.FLock.Unlock()
 		}
 	}()
+
+	if params.EvidencePolicy == mtc.UmbilicalEvidencePolicy {
+		umbRoots := opts.UmbilicalRootsPEM
+
+		if umbRoots == nil {
+			slog.Warn(fmt.Sprintf(
+				"You did not specify umbilical roots. Fetching from CA instead. " +
+					"Do you trust them?",
+			))
+			umbRoots, err = get(h.url("umbilical-roots.pem"))
+			if err != nil {
+				return nil, err
+			}
+		}
+		if !x509.NewCertPool().AppendCertsFromPEM(umbRoots) {
+			return nil, errors.New(
+				"Failed to parse umbilical roots",
+			)
+		}
+		if err := os.WriteFile(
+			h.b.UmbilicalRootsPath(),
+			umbRoots,
+			0o644,
+		); err != nil {
+			return nil, fmt.Errorf("Writing %s: %w", h.b.UmbilicalRootsPath(), err)
+		}
+	}
 
 	unlock = false
 	return &h, nil
@@ -249,6 +298,8 @@ func (h *Handle) fetchBatch(number uint32) error {
 		CA:     &h.b.Params,
 	}
 
+	batchStart, batchEnd := batch.ValidityInterval()
+
 	// We write the batch into a temporary directory until it's all
 	// checked out.
 	deleteDir := true
@@ -268,7 +319,8 @@ func (h *Handle) fetchBatch(number uint32) error {
 	// if applicable umbilical-certificates. The rest we recompute.
 	besPath := gopath.Join(dir, "entries")
 	svwPath := gopath.Join(dir, "validity-window")
-	evPath := gopath.Join(dir, "evidence")
+	evsPath := gopath.Join(dir, "evidence")
+	ucPath := gopath.Join(dir, "umbilical-certificates")
 
 	prefix := fmt.Sprintf("batches/%d/", number)
 
@@ -290,42 +342,190 @@ func (h *Handle) fetchBatch(number uint32) error {
 
 	if err := getAndStore(
 		h.url(prefix+"evidence"),
-		evPath,
+		evsPath,
 	); err != nil {
 		return err
 	}
 
-	// TODO umbilical certificates
+	var (
+		ucs      []*frozencas.Handle
+		umbRoots *x509.CertPool
+	)
+	if h.b.Params.EvidencePolicy == mtc.UmbilicalEvidencePolicy {
+		umbRoots, err = h.b.GetUmbilicalRoots()
+		if err != nil {
+			return err
+		}
+
+		if err := getAndStore(
+			h.url(prefix+"umbilical-certificates"),
+			ucPath,
+		); err != nil {
+			return err
+		}
+
+		// Oldest batch to inspect for deduplicated umbilical certificate
+		end := int64(batch.Number) - int64(h.b.Params.ValidityWindowSize)
+		if end < 0 {
+			end = 0
+		}
+
+		for bn := int64(batch.Number) - 1; bn >= end; bn-- {
+			uc, err := h.b.UCFor(uint32(bn))
+			if err != nil {
+				return fmt.Errorf(
+					"opening umbilical certificates for batch %d: %w",
+					bn,
+					err,
+				)
+			}
+
+			ucs = append(ucs, uc)
+		}
+	}
 
 	var svw mtc.SignedValidityWindow
 	if err := svw.UnmarshalBinary(svwBuf, &h.b.Params); err != nil {
 		return fmt.Errorf("parsing validity-window: %w", err)
 	}
 
-	// Recompute tree
+	// Prepare to recompute tree and check evidence
 	tb := batch.NewTreeBuilder()
+
 	besR, err := os.OpenFile(besPath, os.O_RDONLY, 0)
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", besPath, err)
 	}
 	defer besR.Close()
 
+	evsR, err := os.OpenFile(evsPath, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", evsPath, err)
+	}
+	defer evsR.Close()
+
 	besC := mtc.UnmarshalBatchEntries(bufio.NewReader(besR))
 	defer besC.Close()
 
-	var be mtc.BatchEntry
+	evsC := mtc.UnmarshalEvidenceLists(bufio.NewReader(evsR))
+	defer evsC.Close()
+
+	var (
+		be  mtc.BatchEntry
+		evs mtc.EvidenceList
+	)
+
+	entryNumber := -1
 	for {
-		err := besC.Pull(&be)
-		if err == mtc.EOF {
+		entryNumber++
+		err1 := besC.Pull(&be)
+		err2 := evsC.Pull(&evs)
+		if err1 == mtc.EOF && err1 == err2 {
 			break
 		}
-
-		if err != nil {
-			return fmt.Errorf("reading %s: %w", besPath, err)
+		if err1 != nil {
+			return fmt.Errorf("reading %s: %w", besPath, err1)
+		}
+		if err2 != nil {
+			return fmt.Errorf("reading %s: %w", evsPath, err2)
 		}
 
 		if err := tb.Push(&be); err != nil {
 			return fmt.Errorf("building tree: %w", err)
+		}
+
+		// TODO Would the spec allow a small NotAfter?
+		//		What about not_after = batchStart?
+		if be.NotAfter.After(batchEnd) || be.NotAfter.Before(batchStart) {
+			return fmt.Errorf(
+				"entry %d has not_after %s out of range [%s, %s]",
+				entryNumber,
+				be.NotAfter.UTC(),
+				batchStart.UTC(),
+				batchEnd.UTC(),
+			)
+		}
+
+		if h.b.Params.EvidencePolicy != mtc.UmbilicalEvidencePolicy {
+			continue
+		}
+
+		// Reconstruct umbilical chain
+		var chain []*x509.Certificate
+		for _, ev := range evs {
+			switch ev.Type() {
+			case mtc.UmbilicalEvidenceType:
+				chain, err = ev.(mtc.UmbilicalEvidence).Chain()
+				if err != nil {
+					return fmt.Errorf(
+						"parsing umbilical chain #%d: %w",
+						entryNumber,
+						err,
+					)
+				}
+				break
+			case mtc.CompressedUmbilicalEvidenceType:
+				hashes := ev.(mtc.CompressedUmbilicalEvidence).Chain()
+				for _, hash := range hashes {
+					var rawCert []byte
+					for _, uc := range ucs {
+						rawCert, err = uc.Get(hash[:])
+						if err != nil {
+							return err
+						}
+						if rawCert != nil {
+							break
+						}
+					}
+
+					if rawCert == nil {
+						return fmt.Errorf(
+							"Could not find umbilical certificate for entry %d with hash %x",
+							entryNumber,
+							hash,
+						)
+					}
+
+					cert, err := x509.ParseCertificate(rawCert)
+					if err != nil {
+						return fmt.Errorf(
+							"Could not parse umbilical certificate for entry %d with hash %x",
+							entryNumber,
+							hash,
+						)
+					}
+
+					chain = append(chain, cert)
+				}
+				break
+			default:
+				continue
+			}
+		}
+
+		if chain == nil {
+			return fmt.Errorf("No umbilical chain present for entry %d", entryNumber)
+		}
+
+		if len(chain) == 0 {
+			return fmt.Errorf("Umbilical chain empty for entry %d", entryNumber)
+		}
+
+		_, err = umbilical.CheckClaimsValidForX509(
+			be.Claims,
+			be.Subject,
+			batchStart,
+			be.NotAfter,
+			chain,
+			umbRoots,
+			nil,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"Checking umbilical chain for entry %d: %w",
+				entryNumber,
+				err,
+			)
 		}
 	}
 
@@ -396,7 +596,6 @@ func (h *Handle) fetchBatch(number uint32) error {
 		)
 	}
 
-	// TODO check evidence
 	// TODO do we care about creating an index?
 
 	h.b.BatchNumbersCache = nil // Invalidate cache of existing batches

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -364,6 +364,13 @@ func (h *Handle) fetchBatch(number uint32) error {
 			return err
 		}
 
+		newUc, err := frozencas.Open(ucPath)
+		if err != nil {
+			return fmt.Errorf("failed to open umbilical-certificates: %w", err)
+		}
+		defer newUc.Close()
+		ucs = append(ucs, newUc)
+
 		// Oldest batch to inspect for deduplicated umbilical certificate
 		end := int64(batch.Number) - int64(h.b.Params.ValidityWindowSize)
 		if end < 0 {

--- a/mtc.go
+++ b/mtc.go
@@ -85,11 +85,14 @@ type UnknownEvidence struct {
 type EvidencePolicyType uint16
 
 const (
+	// No policy set.
+	UnsetEvidencePolicy EvidencePolicyType = iota
+
 	// Policy requiring no evidence to queue an assertion request.
-	EmptyEvidencePolicyType EvidencePolicyType = iota
+	EmptyEvidencePolicy
 
 	// Policy requiring an X509 chain to an accepted root to queue an assertion request.
-	UmbilicalEvidencePolicyType
+	UmbilicalEvidencePolicy
 )
 
 // Represents a claim we do not how to interpret.

--- a/umbilical/x509.go
+++ b/umbilical/x509.go
@@ -89,7 +89,7 @@ func GetChainFromTLSServer(addr string) (chain []*x509.Certificate, err error) {
 	return
 }
 
-// Checks whether the given claims (to be) issued for the subject  is
+// Checks whether the given claims (to be) issued for the subject are
 // consistent with the given X.509 certificate chain and accepted roots
 // for the given validity interval. The claims are allowed to cover less than
 // the certificate: eg, only example.com where the certificate


### PR DESCRIPTION
All functionality is there—just need to test it.

Note that this includes a backwards incompatible change to EvidencePolicyType (adding a zero value.)